### PR TITLE
Adding autotools support for easier install.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.deps
+Makefile.in
+aclocal.m4
+autom4te.cache
+compile
+configure
+depcomp
+install-sh
+missing
+npstat

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,0 @@
-all: npstat
-
-
-npstat: 
-	gcc -o npstat NPStat-v1.c -lgsl -lgslcblas -lm
-
-clean: 
-	rm npstat

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,5 +4,5 @@ bin_PROGRAMS = npstat
 
 npstat_SOURCES = NPStat-v1.c
 
-# npstat_CFLAGS = $(CSL_CFLAGS)
-# npstat_LDFLAGS = $(GSL_LIBS)
+npstat_CFLAGS = $(GSL_CFLAGS)
+npstat_LDFLAGS = $(GSL_LIBS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,8 @@
+
+
+bin_PROGRAMS = npstat
+
+npstat_SOURCES = NPStat-v1.c
+
+# npstat_CFLAGS = $(CSL_CFLAGS)
+# npstat_LDFLAGS = $(GSL_LIBS)

--- a/aclocal/gsl.m4
+++ b/aclocal/gsl.m4
@@ -1,0 +1,162 @@
+# Configure path for the GNU Scientific Library
+# Christopher R. Gabriel <cgabriel@linux.it>, April 2000
+
+
+AC_DEFUN([AX_PATH_GSL],
+[
+AC_ARG_WITH(gsl-prefix,[  --with-gsl-prefix=PFX   Prefix where GSL is installed (optional)],
+            gsl_prefix="$withval", gsl_prefix="")
+AC_ARG_WITH(gsl-exec-prefix,[  --with-gsl-exec-prefix=PFX Exec prefix where GSL is installed (optional)],
+            gsl_exec_prefix="$withval", gsl_exec_prefix="")
+AC_ARG_ENABLE(gsltest, [  --disable-gsltest       Do not try to compile and run a test GSL program],
+		    , enable_gsltest=yes)
+
+  if test "x${GSL_CONFIG+set}" != xset ; then
+     if test "x$gsl_prefix" != x ; then
+         GSL_CONFIG="$gsl_prefix/bin/gsl-config"
+     fi
+     if test "x$gsl_exec_prefix" != x ; then
+        GSL_CONFIG="$gsl_exec_prefix/bin/gsl-config"
+     fi
+  fi
+
+  AC_PATH_PROG(GSL_CONFIG, gsl-config, no)
+  min_gsl_version=ifelse([$1], ,0.2.5,$1)
+  AC_MSG_CHECKING(for GSL - version >= $min_gsl_version)
+  no_gsl=""
+  if test "$GSL_CONFIG" = "no" ; then
+    no_gsl=yes
+  else
+    GSL_CFLAGS=`$GSL_CONFIG --cflags`
+    GSL_LIBS=`$GSL_CONFIG --libs`
+
+    gsl_major_version=`$GSL_CONFIG --version | \
+           sed 's/^\([[0-9]]*\).*/\1/'`
+    if test "x${gsl_major_version}" = "x" ; then
+       gsl_major_version=0
+    fi
+
+    gsl_minor_version=`$GSL_CONFIG --version | \
+           sed 's/^\([[0-9]]*\)\.\{0,1\}\([[0-9]]*\).*/\2/'`
+    if test "x${gsl_minor_version}" = "x" ; then
+       gsl_minor_version=0
+    fi
+
+    gsl_micro_version=`$GSL_CONFIG --version | \
+           sed 's/^\([[0-9]]*\)\.\{0,1\}\([[0-9]]*\)\.\{0,1\}\([[0-9]]*\).*/\3/'`
+    if test "x${gsl_micro_version}" = "x" ; then
+       gsl_micro_version=0
+    fi
+
+    if test "x$enable_gsltest" = "xyes" ; then
+      ac_save_CFLAGS="$CFLAGS"
+      ac_save_LIBS="$LIBS"
+      CFLAGS="$CFLAGS $GSL_CFLAGS"
+      LIBS="$LIBS $GSL_LIBS"
+
+      rm -f conf.gsltest
+      AC_TRY_RUN([
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+char* my_strdup (const char *str);
+
+char*
+my_strdup (const char *str)
+{
+  char *new_str;
+  
+  if (str)
+    {
+      new_str = (char *)malloc ((strlen (str) + 1) * sizeof(char));
+      strcpy (new_str, str);
+    }
+  else
+    new_str = NULL;
+  
+  return new_str;
+}
+
+int main (void)
+{
+  int major = 0, minor = 0, micro = 0;
+  int n;
+  char *tmp_version;
+
+  system ("touch conf.gsltest");
+
+  /* HP/UX 9 (%@#!) writes to sscanf strings */
+  tmp_version = my_strdup("$min_gsl_version");
+
+  n = sscanf(tmp_version, "%d.%d.%d", &major, &minor, &micro) ;
+
+  if (n != 2 && n != 3) {
+     printf("%s, bad version string\n", "$min_gsl_version");
+     exit(1);
+   }
+
+   if (($gsl_major_version > major) ||
+      (($gsl_major_version == major) && ($gsl_minor_version > minor)) ||
+      (($gsl_major_version == major) && ($gsl_minor_version == minor) && ($gsl_micro_version >= micro)))
+     { 
+       exit(0);
+     }   
+   else
+     {
+       exit(1);
+     }
+}
+
+],, no_gsl=yes,[echo $ac_n "cross compiling; assumed OK... $ac_c"])
+       CFLAGS="$ac_save_CFLAGS"
+       LIBS="$ac_save_LIBS"
+     fi
+  fi
+  if test "x$no_gsl" = x ; then
+     AC_MSG_RESULT(yes)
+     ifelse([$2], , :, [$2])     
+  else
+     AC_MSG_RESULT(no)
+     if test "$GSL_CONFIG" = "no" ; then
+       echo "*** The gsl-config script installed by GSL could not be found"
+       echo "*** If GSL was installed in PREFIX, make sure PREFIX/bin is in"
+       echo "*** your path, or set the GSL_CONFIG environment variable to the"
+       echo "*** full path to gsl-config."
+     else
+       if test -f conf.gsltest ; then
+        :
+       else
+          echo "*** Could not run GSL test program, checking why..."
+          CFLAGS="$CFLAGS $GSL_CFLAGS"
+          LIBS="$LIBS $GSL_LIBS"
+          AC_TRY_LINK([
+#include <stdio.h>
+],      [ return 0; ],
+        [ echo "*** The test program compiled, but did not run. This usually means"
+          echo "*** that the run-time linker is not finding GSL or finding the wrong"
+          echo "*** version of GSL. If it is not finding GSL, you'll need to set your"
+          echo "*** LD_LIBRARY_PATH environment variable, or edit /etc/ld.so.conf to point"
+          echo "*** to the installed location  Also, make sure you have run ldconfig if that"
+          echo "*** is required on your system"
+	  echo "***"
+          echo "*** If you have an old version installed, it is best to remove it, although"
+          echo "*** you may also be able to get things to work by modifying LD_LIBRARY_PATH"],
+        [ echo "*** The test program failed to compile or link. See the file config.log for the"
+          echo "*** exact error that occured. This usually means GSL was incorrectly installed"
+          echo "*** or that you have moved GSL since it was installed. In the latter case, you"
+          echo "*** may want to edit the gsl-config script: $GSL_CONFIG" ])
+          CFLAGS="$ac_save_CFLAGS"
+          LIBS="$ac_save_LIBS"
+       fi
+     fi
+#     GSL_CFLAGS=""
+#     GSL_LIBS=""
+     ifelse([$3], , :, [$3])
+  fi
+  AC_SUBST(GSL_CFLAGS)
+  AC_SUBST(GSL_LIBS)
+  rm -f conf.gsltest
+])
+
+AU_ALIAS([AM_PATH_GSL], [AX_PATH_GSL])

--- a/configure.ac
+++ b/configure.ac
@@ -1,3 +1,4 @@
+#                                               -*- Autoconf -*-
 
 AC_INIT([npstat], [1.0.0], [lucaferretti@users-no-reply.github.com])
 
@@ -7,14 +8,16 @@ AC_CONFIG_MACRO_DIR([aclocal])
 
 AC_PROG_CC
 AM_PROG_CC_C_O
-AX_PATH_GSL
+GSL_MIN_VERSION=1.8
+AX_PATH_GSL([$GSL_MIN_VERSION], [],
+  [AC_MSG_ERROR([(Could not find GSL version >=$GSL_MIN_VERSION.])])
 
 AC_CHECK_HEADER([stdio.h])
 
 ## From: https://www.gnu.org/software/gsl/manual/html_node/Autoconf-Macros.html#Autoconf-Macros
-AC_CHECK_LIB([m],[cos])
-AC_CHECK_LIB([gslcblas],[cblas_dgemm])
-AC_CHECK_LIB([gsl],[gsl_blas_dgemm])
+#AC_CHECK_LIB([m],[cos])
+#AC_CHECK_LIB([gslcblas],[cblas_dgemm], [], [AC_MSG_ERROR(["libgslcblas is required"])], [])
+#AC_CHECK_LIB([gsl],[gsl_blas_dgemm], [], [AC_MSG_ERROR(["libgsl is required"])])
 
 ## autoscan output
 AC_CHECK_FUNCS([getdelim])

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,30 @@
+
+AC_INIT([npstat], [1.0.0], [lucaferretti@users-no-reply.github.com])
+
+AM_INIT_AUTOMAKE([-Wall foreign])
+
+AC_CONFIG_MACRO_DIR([aclocal])
+
+AC_PROG_CC
+AM_PROG_CC_C_O
+AX_PATH_GSL
+
+AC_CHECK_HEADER([stdio.h])
+
+## From: https://www.gnu.org/software/gsl/manual/html_node/Autoconf-Macros.html#Autoconf-Macros
+AC_CHECK_LIB([m],[cos])
+AC_CHECK_LIB([gslcblas],[cblas_dgemm])
+AC_CHECK_LIB([gsl],[gsl_blas_dgemm])
+
+## autoscan output
+AC_CHECK_FUNCS([getdelim])
+AC_CHECK_FUNCS([sqrt])
+AC_FUNC_MALLOC
+AC_FUNC_REALLOC
+AC_PREREQ
+AC_TYPE_SIZE_T
+
+
+AC_CONFIG_FILES([Makefile])
+
+AC_OUTPUT


### PR DESCRIPTION
Hi,

I know autotools isn't everyone's favourite, but here's a pull request to add it as a favour for a colleague, having trouble building `npstat`.

## build workflow

```bash
autoreconf -if
./configure
make
make install
```